### PR TITLE
Improve ZF3 compatibility

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -6,6 +6,7 @@ namespace ZF\Doctrine\DataFixture\Controller;
 
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
 use Zend\Mvc\Console\Controller\AbstractConsoleController;
 use ZF\Doctrine\DataFixture\DataFixtureManager;
 use ZF\Doctrine\DataFixture\Loader;
@@ -49,10 +50,16 @@ class ImportController extends AbstractConsoleController
             $purger->setPurgeMode(ORMPurger::PURGE_MODE_TRUNCATE);
         }
 
-        $executor = new ORMExecutor(
-            $this->dataFixtureManager->getObjectManager(),
-            $purger
-        );
+        $objectManager = $this->dataFixtureManager->getObjectManager();
+        if (! $objectManager instanceof EntityManagerInterface) {
+            throw new \RuntimeException(sprintf(
+                'Invalid Object Manager, %s must implement %s',
+                get_class($objectManager),
+                EntityManagerInterface::class
+            ));
+        }
+
+        $executor = new ORMExecutor($objectManager, $purger);
         $executor->execute(
             $loader->getFixtures(),
             (bool)! $this->params()->fromRoute('do-not-append')

--- a/src/DataFixtureManager.php
+++ b/src/DataFixtureManager.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 namespace ZF\Doctrine\DataFixture;
 
+use Doctrine\Common\DataFixtures\FixtureInterface;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use DoctrineModule\Persistence\ProvidesObjectManager;
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\AbstractPluginManager;
 
-class DataFixtureManager extends ServiceManager implements ObjectManagerAwareInterface
+class DataFixtureManager extends AbstractPluginManager implements ObjectManagerAwareInterface
 {
     use ProvidesObjectManager;
+
+    /**
+     * @inheritdoc
+     */
+    protected $instanceOf = FixtureInterface::class;
 
     /**
      * @var string
      */
     protected $objectManagerAlias;
-
-    /**
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Get all data fixtures
@@ -59,27 +59,5 @@ class DataFixtureManager extends ServiceManager implements ObjectManagerAwareInt
     public function setObjectManagerAlias(string $alias): void
     {
         $this->objectManagerAlias = $alias;
-    }
-
-    /**
-     * Get the service locator
-     *
-     * @return ContainerInterface
-     */
-    public function getServiceLocator(): ContainerInterface
-    {
-        return $this->serviceLocator;
-    }
-
-    /**
-     * Set the service locator
-     *
-     * @param ContainerInterface $serviceLocator
-     *
-     * @return void
-     */
-    public function setServiceLocator(ContainerInterface $serviceLocator): void
-    {
-        $this->serviceLocator = $serviceLocator;
     }
 }

--- a/src/DataFixtureManagerFactory.php
+++ b/src/DataFixtureManagerFactory.php
@@ -32,18 +32,19 @@ class DataFixtureManagerFactory implements FactoryInterface
         }
 
         // Check for object manager
-        $groupConfig = $config['doctrine']['fixture'][$fixtureGroup];
+        $groupConfig = (array)$config['doctrine']['fixture'][$fixtureGroup];
         if (! isset($groupConfig['object_manager'])) {
             throw new \RuntimeException(sprintf(
                 'Object manager not specified for fixture group %s',
                 $fixtureGroup
             ));
         }
-
-        // Load instance
         $objectManagerAlias = (string)$groupConfig['object_manager'];
-        $instance           = new DataFixtureManager((array)$groupConfig);
-        $instance->setServiceLocator($container);
+
+        /**
+         * @var DataFixtureManager $instance
+         */
+        $instance = new $requestedName($container, $groupConfig);
         $instance->setObjectManagerAlias($objectManagerAlias);
         $instance->setObjectManager($container->get($objectManagerAlias));
 


### PR DESCRIPTION
This PR includes:
- Refactor ```DataFixtureManager``` to inherit from ```AbstractPluginManager``` instead of ```ServiceManager```
- Throw exception if ```DataFixtureManager::getObjectManager()``` does not return an implementation of ```EntityManagerInterface```
- ```DataFixtureManagerFactory``` now instantiates the provided ```$requestedName``` argument instead of hardcoding the class, allowing reuse of the factory should anyone wish to extend ```DataFixtureManager```

See: https://github.com/API-Skeletons/zf-doctrine-data-fixture/issues/4
